### PR TITLE
Remove guard condition for coords of MarkerView

### DIFF
--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -560,17 +560,8 @@ open class ChartViewBase: NSUIView, ChartDataProvider, ChartAnimatorDelegate
 
                 // callbacks to update the content
                 marker!.refreshContent(entry: e!, highlight: highlight)
-
-                let markerSize = marker!.size
-                if (pos.y - markerSize.height <= 0.0)
-                {
-                    let y = markerSize.height - pos.y
-                    marker!.draw(context: context, point: CGPoint(x: pos.x, y: pos.y + y))
-                }
-                else
-                {
-                    marker!.draw(context: context, point: pos)
-                }
+                
+                marker!.draw(context: context, point: pos)
             }
         }
     }


### PR DESCRIPTION
This guard conditions are already in place at the client side.
This unnecessarily gives the wrong x,y coordinates.