### PR TITLE
Add custom highlight view and preDraw method

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -275,6 +275,8 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         // drawLegend()
 
         drawMarkers(context: context)
+        
+        drawCustomHighlight(context: context);
 
         drawDescription(context: context)
     }

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -535,7 +535,11 @@ open class ChartViewBase: NSUIView, ChartDataProvider, ChartAnimatorDelegate
     /// draws all MarkerViews on the highlighted positions
     internal func drawMarkers(context: CGContext)
     {
-        drawHighlight(context: context, markerItem: marker, isDrawEnabled: drawMarkers);
+        drawHighlight(
+            context: context,
+            markerItem: marker,
+            isDrawEnabled: drawMarkers
+        );
     }
     
     // MARK: - CustomHighlight
@@ -543,13 +547,21 @@ open class ChartViewBase: NSUIView, ChartDataProvider, ChartAnimatorDelegate
     // Draws a custom view on highlight
     internal func drawCustomHighlight(context: CGContext)
     {
-        drawHighlight(context: context, markerItem: customHightlightItem, isDrawEnabled: drawCustomHighlight);
+        drawHighlight(
+            context: context,
+            markerItem: customHightlightItem,
+            isDrawEnabled: drawCustomHighlight
+        );
     }
     
     // MARK: - DrawHighlight
     
     // Draws the highlight for the required item.
-    internal func drawHighlight(context: CGContext, markerItem: ChartMarker?, isDrawEnabled: Bool){
+    internal func drawHighlight(
+        context: CGContext,
+        markerItem: ChartMarker?,
+        isDrawEnabled: Bool
+    ){
         if (markerItem != nil && isDrawEnabled && valuesToHighlight()){
             for i in 0 ..< _indicesToHighlight.count
             {
@@ -573,8 +585,8 @@ open class ChartViewBase: NSUIView, ChartDataProvider, ChartAnimatorDelegate
                         continue
                     }
                     
-                    // callbacks to update the content
                     markerItem!.refreshContent(entry: e!, highlight: highlight)
+                    markerItem!.preDraw(chartData: _data, highlight: highlight);
                     
                     markerItem!.draw(context: context, point: pos)
                 }

--- a/Charts/Classes/Components/ChartMarker.swift
+++ b/Charts/Classes/Components/ChartMarker.swift
@@ -66,4 +66,11 @@ open class ChartMarker: NSObject
     {
         // Do nothing here...
     }
+    
+    // This shares the chart data with the client to perform necessary changes before the drawing start.
+    open func preDraw(chartData: ChartData?, highlight: ChartHighlight)
+    {
+        // This is just an empty stub...
+    }
+
 }


### PR DESCRIPTION
The following changes were made - 
- Add custom view which can be setup for highlighting purposes apart from the marker view.
- Add preDraw method to the abstract class chartMarker, which can expose data to the client. This can be useful for setting up before the draw method is actually called. 